### PR TITLE
Fix an example in the documentation

### DIFF
--- a/lib/Markdown/Table.pm
+++ b/lib/Markdown/Table.pm
@@ -224,7 +224,7 @@ document.
     This table shows all employees and their role.
 
     | Id | Name | Role |
-    +---+---+---+
+    |---|---|---|
     | 1 | John Smith | Testrole |
     | 2 | Jane Smith | Admin |
     ~;


### PR DESCRIPTION
Previously, it was using the nuclino syntax for the table, but didn't turn the special parsing on (which is not documented, anyway).